### PR TITLE
fix single poll null writes

### DIFF
--- a/src/services/polling/modbus_polling.py
+++ b/src/services/polling/modbus_polling.py
@@ -96,7 +96,7 @@ class ModbusPolling(metaclass=Singleton):
                 self.__log_debug(f'Device {device.uuid} aggregate R/W UNSUPPORTED')
                 for point in points:
                     try:
-                        if point.is_writable(point.function_code) and not self.is_point_to_be_written(point):
+                        if not self.is_point_to_be_written(point):
                             continue
                         self.__poll_point(current_connection.client, network, device, [point])
                     except ConnectionException:

--- a/src/services/polling/modbus_polling.py
+++ b/src/services/polling/modbus_polling.py
@@ -96,6 +96,8 @@ class ModbusPolling(metaclass=Singleton):
                 self.__log_debug(f'Device {device.uuid} aggregate R/W UNSUPPORTED')
                 for point in points:
                     try:
+                        if point.is_writable(point.function_code) and not self.is_point_to_be_written(point):
+                            continue
                         self.__poll_point(current_connection.client, network, device, [point])
                     except ConnectionException:
                         return


### PR DESCRIPTION
from v1.0.5, non `support-multiple-rw` devices would write points with null write value again